### PR TITLE
Fixes an Issue with randomization of Enemy Lists

### DIFF
--- a/scripts/init.lua
+++ b/scripts/init.lua
@@ -18,6 +18,9 @@ end
 
 function extension:init(options)
 	local path = self.resourcePath
+	--Add randomization
+	math.randomseed(os.time())
+	math.random()
 
 	require(path.."modules/events")
 	require(path.."modules/indexedList")


### PR DESCRIPTION
Without the Fix: 

Steps to Recreate:
1. Boot the game. 
2. Create a New Game and start it
3. Record which Vek the first island contains (or more islands) 
4. Close the game and reboot
5. Create a New Game and Start it
6. Note that the current Vek are the same as the previously recorded Vek
7. Repeat Any Number of Times

With the Fix: 

1. Repeat the same steps, but note that the Vek are properly different on the island each reboot.