### PR TITLE
Add Unfair to the difficulty list

### DIFF
--- a/alter.lua
+++ b/alter.lua
@@ -6,7 +6,7 @@ sdlext.surface_cache_max = 1024
 local path = GetParentPath(...)
 
 local vanillaCorporations = { "Corp_Grass", "Corp_Desert", "Corp_Snow", "Corp_Factory" }
-local difficulties = { DIFF_EASY, DIFF_NORMAL, DIFF_HARD }
+local difficulties = { DIFF_EASY, DIFF_NORMAL, DIFF_HARD, DIFF_UNFAIR }
 
 local islands = { "archive", "rst", "pinnacle", "detritus" }
 local islandNames = { "Archive", "R.S.T.", "Pinnacle", "Detritus" }


### PR DESCRIPTION
With Unfair missing from the difficulty list, easyEdit messes up island terrain generation and enemy lists (examples: not populating Pinnacle maps with random ice, RST with random sand; not seeing all Psions appear).