### PR TITLE
Prevents Multiple Flying Enemies on one Island

### DIFF
--- a/alter.lua
+++ b/alter.lua
@@ -610,6 +610,12 @@ function pickEnemies(categories, enemies, islandNumber, timesPicked)
 				end
 			end
 		end
+		--Flying Enemies
+		if FlyingEnemies[unit] then --If flying exclude all flying
+			for excludedId, _ in pairs(FlyingEnemies) do
+				excluded[excludedId] = true
+			end
+		end
 	end
 
 	local function getEnemyChoices(category)


### PR DESCRIPTION
Fixes an issue where multiple flying enemies could spawn on each island. This new feature was added during AE due to 2 more flying enemies, but was never caught by easyEdit