### PR TITLE
Fix Unique Boss Issue

### DIFF
--- a/alter.lua
+++ b/alter.lua
@@ -69,7 +69,7 @@ local MISSION_EXCLUSION = {
 }
 
 local STRUCTURE_EXCLUSION = {
-	
+
 }
 
 local function updateMissingNames()
@@ -281,7 +281,7 @@ local function appendMissionImage(mission_id, subpath)
 end
 
 local function appendMissionSmallImage(mission_id)
-	
+
 end
 
 local function registerMission(mission_id)
@@ -426,6 +426,7 @@ local function registerCorporations()
 		local base = _G[corp_id]
 
 		corp:copy(base)
+		base.OldUniqueBosses = base.UniqueBosses
 		base.UniqueBosses = {}
 		corp.Name = GetText(corp_id.."_Name")
 		corp.Description = GetText(corp_id.."_Description")

--- a/modules/bossList.lua
+++ b/modules/bossList.lua
@@ -11,8 +11,8 @@ end
 function BossList:copy(base)
 	if type(base) ~= 'table' then return end
 
-	if base.UniqueBosses then
-		self.Bosses = add_arrays(base.Bosses, base.UniqueBosses)
+	if base.OldUniqueBosses then
+		self.Bosses = add_arrays(base.Bosses, base.OldUniqueBosses)
 	else
 		self.Bosses = copy_table(base.Bosses)
 	end


### PR DESCRIPTION
Fixes an issue posted on the modloader issues page where the bot leader wasn't showing up on the Pinnacle Boss List https://github.com/itb-community/ITB-ModLoader/issues/182#issue-1501496701

Copies the Unique Boss list when it is reset to empty and uses that copy when reading.

Steps to Replicate:
1. Open the game
2. See the Pinnacle Boss List does not have the bot leader

1. Get the changes and open the game
2. REQUIRED: You have to hit default on the boss list to see the new changes because of save data. So the bug may continue for other users until the hit default. 
3. See the Pinnacle Boss List does have the bot leader

P.S. Sorry for the white space changes, my editor did that itself and I couldn't find how to turn it off. 