### PR TITLE
Add event onGeneratingTerrain

### DIFF
--- a/alter.lua
+++ b/alter.lua
@@ -558,6 +558,8 @@ local function registerTilesets()
 			return 0
 		end
 
+		easyEdit.events.onGeneratingTerrain:dispatch(sectorType)
+
 		return tileset:getRainChance()
 	end
 

--- a/modules/events.lua
+++ b/modules/events.lua
@@ -1,3 +1,4 @@
 
 easyEdit.events = {}
 easyEdit.events.onEditorButtonSet = Event()
+easyEdit.events.onGeneratingTerrain = Event()


### PR DESCRIPTION
This event is called once at the start of a mission, when terrain is generated for the mission. It uses the entry point `getRainChance`, which is also only checked once at the start of a mission.

## For documentation

### Signature of the event handler
`void event_handler(tileset_id)`

### Example
```lua
local event_handler = function(tileset_id)
    LOG("Generating terrain for tileset ", tileset)
end

easyEdit.events.onGeneratingTerrain:subscribe(event_handler)
```