### PR TITLE
Add IndexedEntry:unlock()

### DIFF
--- a/modules/indexedList.lua
+++ b/modules/indexedList.lua
@@ -285,6 +285,19 @@ function IndexedEntry:lock()
 	end
 end
 
+function IndexedEntry:unlock()
+	if not self._locked then
+		return
+	end
+
+	self._locked = false
+	setmetatable(self, IndexedEntryMetatableUnlocked)
+
+	for key, entry in pairs(self._default) do
+		self[key] = nil
+	end
+end
+
 function IndexedEntry:delete(save)
 	if not self:isCustom() then
 		return false


### PR DESCRIPTION
Preliminary PR for a very little tested function that will allow changing the default states of Easy Edit lists after Easy Edit has previously locked them.

After Easy Edit has finished initializing, before any mod is initialized, Easy Edit will lock all vanilla Easy Edit lists.
After a mod has finished initializing, before the next mod is initialized, Easy Edit will lock all lists added by this mod.
- Locked lists can have new entries added to it.
- When entries are added to locked lists, it will not affect its default state. Only the current state.
- Clicking the "Default" button on a list will bring the list back to its default state.

If you unlock a list, any edits you do to it will affect its default state.

Example of adding the mission Piston to Archive's default mission list:
```lua
local missionList = easyEdit.missionList:get("archive") 
-- unlock the list so we can edit its default state
missionList:unlock() 
missionList:addMission("Mission_Piston", true) 
-- lock it again to seal it for further edits
missionList:lock()
```