### PR TITLE
Add Edited flag and unlock vanilla lists while mods initialize

### DIFF
--- a/alter.lua
+++ b/alter.lua
@@ -194,7 +194,6 @@ local function registerWeapon(weapon_id)
 	weapon.__Id = weapon_id
 	weapon.Name = GetText(weapon_id.."_Name") or base.Name
 	weapon.Description = GetText(weapon_id.."_Description") or base.Description
-	weapon:lock()
 end
 
 local function registerWeapons()
@@ -225,8 +224,6 @@ local function registerUnit(unit_id)
 
 	if isValidUnit(base) then
 		unit = unit or units:add(unit_id, base)
-		unit:lock()
-
 		units:addSoundBase(unit)
 	end
 
@@ -238,7 +235,6 @@ local function registerUnit(unit_id)
 		unitImage.Name = unitImageId
 		unitImage.Image = base.Image
 		unitImage.ImageOffset = base.ImageOffset
-		unitImage:lock()
 	end
 
 	for _, weaponId in ipairs(base.SkillList) do
@@ -299,7 +295,6 @@ local function registerMission(mission_id)
 
 	mission = mission or easyEdit.missions:add(mission_id)
 	mission:copy(base)
-	mission:lock()
 
 	appendMissionImage(mission_id, "mission/")
 	appendMissionImage(mission_id, "mission/small/")
@@ -358,7 +353,6 @@ local function registerStructure(structure_id)
 	structure = structure or easyEdit.structures:add(structure_id)
 	structure.Name = GetText(structure_id.."_Name")
 	structure:copy(base)
-	structure:lock()
 end
 
 local function registerStructures()
@@ -414,8 +408,6 @@ local function registerIslands()
 				table.insert(island.network, _G["Network_Island_".. n][tostring(k)])
 			end
 		end
-
-		island:lock()
 	end
 end
 
@@ -430,7 +422,6 @@ local function registerCorporations()
 		base.UniqueBosses = {}
 		corp.Name = GetText(corp_id.."_Name")
 		corp.Description = GetText(corp_id.."_Description")
-		corp:lock()
 	end
 end
 
@@ -443,7 +434,6 @@ local function registerCEOs()
 		ceo:copyAssets({_id = "ceo_"..corporations[i]})
 		ceo:copy(base)
 		ceo.CEO_Name = GetText(corp_id.."_CEO_Name")
-		ceo:lock()
 	end
 end
 
@@ -681,7 +671,6 @@ local function registerEnemyLists()
 
 		enemyList.name = base.Bark_Name
 		enemyList.enemies = getFinalEnemyLists()
-		enemyList:lock()
 	end
 
 	for i, corp_id in ipairs(vanillaCorporations) do
@@ -738,7 +727,6 @@ local function registerBossLists()
 		end
 
 		bossList.name = base.Bark_Name
-		bossList:lock()
 	end
 end
 
@@ -750,7 +738,6 @@ local function registerMissionLists()
 
 		missionList:copy(base)
 		missionList.name = base.Bark_Name
-		missionList:lock()
 	end
 end
 
@@ -762,7 +749,6 @@ local function registerStructureLists()
 		local structureList = easyEdit.structureList:add(id)
 		structureList:copy(Corp_Default)
 		structureList.name = base.Bark_Name
-		structureList:lock()
 	end
 end
 
@@ -779,8 +765,6 @@ local function registerIslandComposites()
 		islandComposite.bossList = bossLists[i]
 		islandComposite.enemyList = corporations[i]
 		islandComposite.structureList = corporations[i]
-
-		islandComposite:lock()
 	end
 end
 

--- a/modules/indexedList.lua
+++ b/modules/indexedList.lua
@@ -101,7 +101,15 @@ end
 function IndexedList:save()
 	-- overrideable method
 	local entryType = self:getEntryType()
-	easyEdit.savedata:saveAsDir(entryType, self._children)
+	local data = {}
+
+	for key, child in pairs(self._children) do
+		if child.edited then
+			data[key] = child
+		end
+	end
+
+	easyEdit.savedata:saveAsDir(entryType, data)
 end
 
 -- Update lists from savedata,
@@ -303,6 +311,7 @@ end
 
 function IndexedEntry:reset()
 	self:copy(self._default)
+	self.edited = nil
 end
 
 function IndexedEntry:copy(base)

--- a/ui/deco/DecoButtonExt.lua
+++ b/ui/deco/DecoButtonExt.lua
@@ -10,6 +10,9 @@ function DecoButtonExt:new(...)
 	self.bordertargetcolor = nil
 		or self.borderhlcolor
 		or deco.colors.buttonborderhl
+
+	self.disabledcolor = deco.colors.buttondisabled
+	self.disabledbordercolor = deco.colors.buttonborderdisabled
 end
 
 function DecoButtonExt:isHighlighted(widget)
@@ -31,7 +34,7 @@ function DecoButtonExt:draw(screen, widget)
 
 	if widget.disabled then
 		basecolor = self.disabledcolor
-		bordercolor = self.disabledcolor
+		bordercolor = self.disabledbordercolor
 
 	elseif self:isHighlighted(widget) then
 		basecolor = self.hlcolor

--- a/ui/deco/DecoMultiClickButton.lua
+++ b/ui/deco/DecoMultiClickButton.lua
@@ -1,17 +1,20 @@
 
 local DecoMultiClickButton = Class.inherit(DecoSurfaceAligned)
 
-function DecoMultiClickButton:new(surfaces, surfaceshl, alignH, alignV)
+function DecoMultiClickButton:new(surfaces, surfaceshl, surfacedisabled, alignH, alignV)
 	DecoSurfaceAligned.new(self, surfaces[1], alignH, alignV)
 
 	self.surfaces = shallow_copy(surfaces)
 	self.surfaceshl = shallow_copy(surfaceshl) or self.surfaces
+	self.surfacedisabled = surfacedisabled or self.surfaces[1]
 end
 
 function DecoMultiClickButton:draw(screen, widget)
 	local index = (widget.clickCount or 0) + 1
 
-	if widget.hovered then
+	if widget.disabled then
+		self.surface = self.surfacedisabled
+	elseif widget.hovered then
 		self.surface = self.surfaceshl[index]
 	else
 		self.surface = self.surfaces[index]

--- a/ui/editor_bossList.lua
+++ b/ui/editor_bossList.lua
@@ -272,11 +272,46 @@ local function buildFrameContent(parentUi)
 end
 
 local function buildFrameButtons(buttonLayout)
-	sdlext.buildButton(
-		"Default",
-		"Reset everything to default\n\nWARNING: This will delete all custom boss lists",
-		resetAll
- 	):addTo(buttonLayout)
+	local tooltip = "Reset everything to default\n\nWARNING: This will delete all custom boss lists"
+	local tooltip_disabled = "Everything is already set to default"
+	local button = sdlext.buildButton("Default"):addTo(buttonLayout)
+
+	function button:relayout()
+		self.disabled = true
+
+		for _, contentListContainer in ipairs(contentListContainers.children) do
+			local contentList = contentListContainer.contentList
+			local objectList = contentList.data
+
+			if objectList.edited then
+				self.disabled = false
+				break
+			end
+		end
+
+		if self.disabled then
+			if self.tooltip ~= tooltip_disabled then
+				self:settooltip(tooltip_disabled)
+			end
+		else
+			if self.tooltip ~= tooltip then
+				self:settooltip(tooltip)
+			end
+		end
+
+		Ui.relayout(self)
+	end
+
+	local onclicked = button.onclicked
+	function button:onclicked(button)
+		if self.disabled then
+			return true
+		end
+
+		resetAll()
+
+		return true
+	end
 end
 
 local function onExit()

--- a/ui/editor_enemyList.lua
+++ b/ui/editor_enemyList.lua
@@ -238,6 +238,7 @@ local function buildFrameContent(parentUi)
 		if name:len() > 0 and easyEdit.enemyList:get(name) == nil then
 			local objectList = easyEdit.enemyList:add(name)
 			objectList:lock()
+			objectList.edited = true
 			addObjectList(objectList)
 		end
 
@@ -267,11 +268,46 @@ local function buildFrameContent(parentUi)
 end
 
 local function buildFrameButtons(buttonLayout)
-	sdlext.buildButton(
-		"Default",
-		"Reset everything to default\n\nWARNING: This will delete all custom enemy lists",
-		resetAll
- 	):addTo(buttonLayout)
+	local tooltip = "Reset everything to default\n\nWARNING: This will delete all custom enemy lists"
+	local tooltip_disabled = "Everything is already set to default"
+	local button = sdlext.buildButton("Default"):addTo(buttonLayout)
+
+	function button:relayout()
+		self.disabled = true
+
+		for _, contentListContainer in ipairs(contentListContainers.children) do
+			local contentList = contentListContainer.contentList
+			local objectList = contentList.data
+
+			if objectList.edited then
+				self.disabled = false
+				break
+			end
+		end
+
+		if self.disabled then
+			if self.tooltip ~= tooltip_disabled then
+				self:settooltip(tooltip_disabled)
+			end
+		else
+			if self.tooltip ~= tooltip then
+				self:settooltip(tooltip)
+			end
+		end
+
+		Ui.relayout(self)
+	end
+
+	local onclicked = button.onclicked
+	function button:onclicked(button)
+		if self.disabled then
+			return true
+		end
+
+		resetAll()
+
+		return true
+	end
 end
 
 local function onExit()

--- a/ui/editor_island.lua
+++ b/ui/editor_island.lua
@@ -86,11 +86,13 @@ end
 local function onSend_island(sender, reciever)
 	reciever.data.island = sender.data._id
 	reciever.decorations[3]:updateSurfacesForce(reciever)
+	reciever.data.edited = true
 end
 
 local function mkSend_popup(objName)
 	return function(sender, reciever)
 		reciever.data[objName] = sender.data._id
+		reciever.data.edited = true
 	end
 end
 
@@ -105,6 +107,7 @@ local function mkSend_list(objName)
 	return function(sender, reciever)
 		local objList = easyEdit[objName]:get(sender.data)
 		reciever.data[objName] = sender.data._id
+		reciever.data.edited = true
 		sender.staticContentList.data = sender.data
 		sender.staticContentListLabel.data = sender.data
 	end
@@ -625,12 +628,43 @@ local function buildFrameContent(parentUi)
 end
 
 local function buildFrameButtons(buttonLayout)
+	local tooltip = "Reset everything to default\n\nWARNING: This will delete all custom islands"
+	local tooltip_disabled = "Everything is already set to default"
+	local button = sdlext.buildButton("Default"):addTo(buttonLayout)
 
-	sdlext.buildButton(
-		"Default",
-		"Reset everything to default\n\nWARNING: This will delete all custom islands",
-		resetAll
- 	):addTo(buttonLayout)
+	function button:relayout()
+		self.disabled = true
+
+		for _, island in ipairs(islandList.children) do
+			if island.data.edited then
+				self.disabled = false
+				break
+			end
+		end
+
+		if self.disabled then
+			if self.tooltip ~= tooltip_disabled then
+				self:settooltip(tooltip_disabled)
+			end
+		else
+			if self.tooltip ~= tooltip then
+				self:settooltip(tooltip)
+			end
+		end
+
+		Ui.relayout(self)
+	end
+
+	local onclicked = button.onclicked
+	function button:onclicked(button)
+		if self.disabled then
+			return true
+		end
+
+		resetAll()
+
+		return true
+	end
 end
 
 local function onExit()

--- a/ui/editor_missionList.lua
+++ b/ui/editor_missionList.lua
@@ -267,11 +267,46 @@ local function buildFrameContent(parentUi)
 end
 
 local function buildFrameButtons(buttonLayout)
-	sdlext.buildButton(
-		"Default",
-		"Reset everything to default\n\nWARNING: This will delete all custom mission lists",
-		resetAll
- 	):addTo(buttonLayout)
+	local tooltip = "Reset everything to default\n\nWARNING: This will delete all custom mission lists"
+	local tooltip_disabled = "Everything is already set to default"
+	local button = sdlext.buildButton("Default"):addTo(buttonLayout)
+
+	function button:relayout()
+		self.disabled = true
+
+		for _, contentListContainer in ipairs(contentListContainers.children) do
+			local contentList = contentListContainer.contentList
+			local objectList = contentList.data
+
+			if objectList.edited then
+				self.disabled = false
+				break
+			end
+		end
+
+		if self.disabled then
+			if self.tooltip ~= tooltip_disabled then
+				self:settooltip(tooltip_disabled)
+			end
+		else
+			if self.tooltip ~= tooltip then
+				self:settooltip(tooltip)
+			end
+		end
+
+		Ui.relayout(self)
+	end
+
+	local onclicked = button.onclicked
+	function button:onclicked(button)
+		if self.disabled then
+			return true
+		end
+
+		resetAll()
+
+		return true
+	end
 end
 
 local function onExit()

--- a/ui/editor_structureList.lua
+++ b/ui/editor_structureList.lua
@@ -266,11 +266,46 @@ local function buildFrameContent(parentUi)
 end
 
 local function buildFrameButtons(buttonLayout)
-	sdlext.buildButton(
-		"Default",
-		"Reset everything to default\n\nWARNING: This will delete all custom structure lists",
-		resetAll
- 	):addTo(buttonLayout)
+	local tooltip = "Reset everything to default\n\nWARNING: This will delete all custom structure lists"
+	local tooltip_disabled = "Everything is already set to default"
+	local button = sdlext.buildButton("Default"):addTo(buttonLayout)
+
+	function button:relayout()
+		self.disabled = true
+
+		for _, contentListContainer in ipairs(contentListContainers.children) do
+			local contentList = contentListContainer.contentList
+			local objectList = contentList.data
+
+			if objectList.edited then
+				self.disabled = false
+				break
+			end
+		end
+
+		if self.disabled then
+			if self.tooltip ~= tooltip_disabled then
+				self:settooltip(tooltip_disabled)
+			end
+		else
+			if self.tooltip ~= tooltip then
+				self:settooltip(tooltip)
+			end
+		end
+
+		Ui.relayout(self)
+	end
+
+	local onclicked = button.onclicked
+	function button:onclicked(button)
+		if self.disabled then
+			return true
+		end
+
+		resetAll()
+
+		return true
+	end
 end
 
 local function onExit()

--- a/ui/editor_world.lua
+++ b/ui/editor_world.lua
@@ -49,6 +49,7 @@ local function resetAll()
 		local islandInSlot = islandSlots[i]
 
 		islandInSlot.data = islandComposite
+		islandInSlot.data.edited = false
 	end
 end
 
@@ -262,11 +263,43 @@ local function buildFrameContent(parentUi)
 end
 
 local function buildFrameButtons(buttonLayout)
-	sdlext.buildButton(
-		"Default",
-		"Reset everything to default.",
-		resetAll
- 	):addTo(buttonLayout)
+	local tooltip = "Reset everything to default."
+	local tooltip_disabled = "Everything is already set to default"
+	local button = sdlext.buildButton("Default"):addTo(buttonLayout)
+
+	function button:relayout()
+		self.disabled = true
+
+		for _, island in ipairs(islandSlots) do
+			if island.data.edited then
+				self.disabled = false
+				break
+			end
+		end
+
+		if self.disabled then
+			if self.tooltip ~= tooltip_disabled then
+				self:settooltip(tooltip_disabled)
+			end
+		else
+			if self.tooltip ~= tooltip then
+				self:settooltip(tooltip)
+			end
+		end
+
+		Ui.relayout(self)
+	end
+
+	local onclicked = button.onclicked
+	function button:onclicked(button)
+		if self.disabled then
+			return true
+		end
+
+		resetAll()
+
+		return true
+	end
 end
 
 local function onExit()

--- a/ui/helper_dragObject.lua
+++ b/ui/helper_dragObject.lua
@@ -18,6 +18,7 @@ local function addSaveEntry(ui)
 	local saveId = ui.saveId
 	local saveCategories = objList:getCategories()
 
+	objList.edited = true
 	table.insert(saveCategories[categoryId], saveId)
 end
 
@@ -30,6 +31,7 @@ local function remSaveEntry(ui)
 	local saveId = ui.saveId
 	local saveCategories = objList:getCategories()
 
+	objList.edited = true
 	remove_element(saveId, saveCategories[categoryId])
 end
 

--- a/ui/helper_resetButton.lua
+++ b/ui/helper_resetButton.lua
@@ -35,6 +35,7 @@ modApi.events.onFtldatFinalized:subscribe(function()
 			surfaces.surfaceResetHl,
 			surfaces.surfaceWarningHl
 		},
+		surfaces.surfaceResetDisabled,
 		"center",
 		"center"
 	)
@@ -47,6 +48,7 @@ modApi.events.onFtldatFinalized:subscribe(function()
 			surfaces.surfaceDeleteHl,
 			surfaces.surfaceWarningHl
 		},
+		surfaces.surfaceDeleteDisabled,
 		"center",
 		"center"
 	)
@@ -59,6 +61,7 @@ modApi.events.onFtldatFinalized:subscribe(function()
 			surfaces.surfaceResetSmallHl,
 			surfaces.surfaceWarningSmallHl
 		},
+		surfaces.surfaceResetSmallDisabled,
 		"center",
 		"center"
 	)
@@ -71,6 +74,7 @@ modApi.events.onFtldatFinalized:subscribe(function()
 			surfaces.surfaceDeleteSmallHl,
 			surfaces.surfaceWarningSmallHl
 		},
+		surfaces.surfaceDeleteSmallDisabled,
 		"center",
 		"center"
 	)
@@ -104,6 +108,15 @@ function resetButton_contentList:onclicked()
 	contentList:populate()
 
 	return true
+end
+
+function resetButton_contentList:relayout()
+	local contentListContainer = self.parent
+	local contentList = contentListContainer.contentList
+	local objectList = contentList.data
+
+	self.disabled = not objectList.edited
+	UiMultiClickButton.relayout(self)
 end
 
 

--- a/ui/helper_surfaces.lua
+++ b/ui/helper_surfaces.lua
@@ -8,6 +8,7 @@ local defs = require(path.."helper_defs")
 local COLOR_RED = defs.COLOR_RED
 local TRANSFORM_RED = { { multiply = COLOR_RED } }
 local TRANSFORM_HL = { { multiply = deco.colors.buttonborderhl } }
+local TRANSFORM_DISABLED = { { multiply = deco.colors.buttonborderdisabled } }
 
 
 local helpers = {
@@ -17,16 +18,21 @@ local helpers = {
 modApi.events.onFtldatFinalized:subscribe(function()
 	local surfaceDef = { transformations = TRANSFORM_RED }
 	local surfaceDefHl = { transformations = TRANSFORM_HL }
+	local surfaceDefDisabled = { transformations = TRANSFORM_DISABLED }
 
 	surfaceDef.path = "img/ui/easyEdit/delete.png"
 	surfaceDefHl.path = "img/ui/easyEdit/delete.png"
+	surfaceDefDisabled.path = "img/ui/easyEdit/delete.png"
 	helpers.surfaceDelete = sdlext.getSurface(surfaceDef)
 	helpers.surfaceDeleteHl = sdlext.getSurface(surfaceDefHl)
+	helpers.surfaceDeleteDisabled = sdlext.getSurface(surfaceDefDisabled)
 
 	surfaceDef.path = "img/ui/easyEdit/reset.png"
 	surfaceDefHl.path = "img/ui/easyEdit/reset.png"
+	surfaceDefDisabled.path = "img/ui/easyEdit/reset.png"
 	helpers.surfaceReset = sdlext.getSurface(surfaceDef)
 	helpers.surfaceResetHl = sdlext.getSurface(surfaceDefHl)
+	helpers.surfaceResetDisabled = sdlext.getSurface(surfaceDefDisabled)
 
 	surfaceDef.path = "img/ui/warning_symbol.png"
 	surfaceDefHl.path = "img/ui/warning_symbol.png"
@@ -35,13 +41,17 @@ modApi.events.onFtldatFinalized:subscribe(function()
 
 	surfaceDef.path = "img/ui/easyEdit/delete_small.png"
 	surfaceDefHl.path = "img/ui/easyEdit/delete_small.png"
+	surfaceDefDisabled.path = "img/ui/easyEdit/delete_small.png"
 	helpers.surfaceDeleteSmall = sdlext.getSurface(surfaceDef)
 	helpers.surfaceDeleteSmallHl = sdlext.getSurface(surfaceDefHl)
+	helpers.surfaceDeleteSmallDisabled = sdlext.getSurface(surfaceDefDisabled)
 
 	surfaceDef.path = "img/ui/easyEdit/reset_small.png"
 	surfaceDefHl.path = "img/ui/easyEdit/reset_small.png"
+	surfaceDefDisabled.path = "img/ui/easyEdit/reset_small.png"
 	helpers.surfaceResetSmall = sdlext.getSurface(surfaceDef)
 	helpers.surfaceResetSmallHl = sdlext.getSurface(surfaceDefHl)
+	helpers.surfaceResetSmallDisabled = sdlext.getSurface(surfaceDefDisabled)
 
 	surfaceDef.path = "img/ui/easyEdit/warning_small.png"
 	surfaceDefHl.path = "img/ui/easyEdit/warning_small.png"

--- a/ui/widget/UiDragObject_Island.lua
+++ b/ui/widget/UiDragObject_Island.lua
@@ -17,6 +17,7 @@ function UiDragObject_Island:new(...)
 end
 
 function UiDragObject_Island:onDropTargetDropped(dropTarget)
+	dropTarget.data.edited = true
 	self.data_prev = nil
 end
 

--- a/ui/widget/UiMultiClickButton.lua
+++ b/ui/widget/UiMultiClickButton.lua
@@ -20,7 +20,7 @@ function UiMultiClickButton:setTooltips(tooltips)
 end
 
 function UiMultiClickButton:clicked(button)
-	if button == 1 then
+	if not self.disabled and button == 1 then
 		self.clickCount = self.clickCount + 1
 		if self.clickCount == self.clickTarget then
 			Ui.clicked(self, button)
@@ -32,7 +32,7 @@ function UiMultiClickButton:clicked(button)
 end
 
 function UiMultiClickButton:relayout()
-	if self.focused ~= true then
+	if self.disabled or not self.focused then
 		self.clickCount = 0
 	end
 


### PR DESCRIPTION
### Unlocked Vanilla Lists
Previously Easy Edit fetched all vanilla data, and set that to the vanilla lists' default state before mods were initialized. This caused any mod that wanted to add entries to vanilla lists to only alter their temporary state instead.
Vanilla lists are now kept unlocked and open for edits until all mods have initialized; at which points all lists, vanilla and custom, become locked, preventing calls to Easy Edit to alter their default states.

If your mod wants to only alter the temporary state of an Easy Edit list instead of its default state, the call must be deferred until after all mods have been initialized, and the lists have been locked.
i.e:
```lua
modApi.events.onModsInitialized:subscribe(function()
    -- Call Easy Edit to alter temporary states
end)
```

### Edited Flag
- All entries will now be marked as edited when manually edited by a user
- Only entries marked as edited will be saved to file
- Default buttons will now be grayed out and disabled when all entries are in their default state in the current editor window
- Reset buttons Enemy List, Boss List, Mission List and Structure List will now be grayed out and disabled for individual lists when they are unedited.

### Existing Easy Edit data
Easy Edit data that was saved before this "edited" flag was introduced will not be considered edited. Easy Edit will still load the data on the first boot. However, since the list does not have `["edited"] = true;`, the list will be deleted on the second boot unless it has been manually edited in the editor before exiting the game.